### PR TITLE
Fix HACS repository metadata

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,4 @@
 {
   "name": "Day LT",
-  "render_readme": true,
-  "filename": "ha-lithuanian-date-card.js",
-  "icon": "source1.png",
-  "content_in_root": true
+  "render_readme": true
 }


### PR DESCRIPTION
### Motivation
- Simplify HACS metadata so the repository is recognized as a Home Assistant integration rather than a frontend plugin.
- Remove frontend-specific fields that incorrectly indicated the presence of a frontend resource bundle.

### Description
- Updated `hacs.json` to remove the frontend-only keys `filename`, `icon`, and `content_in_root`.
- Kept `render_readme` in `hacs.json` so the README continues to be rendered in HACS.
- The change ensures the repository will be treated as a custom integration by HACS.

### Testing
- No automated tests were run for this metadata-only change.
- The modification is limited to `hacs.json` and does not affect integration code or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69667325df608327a88a60a0a093996f)